### PR TITLE
Rename HashtagsId property

### DIFF
--- a/UoWRepo/Core/BaseDomain/IArticleDataModel.cs
+++ b/UoWRepo/Core/BaseDomain/IArticleDataModel.cs
@@ -28,7 +28,7 @@ public interface IArticleDataModel : IBaseTEntity
 
     public string TitleForUrl { get; set; }
 
-    public int? HashtagsId { get; set; }
+    public int? HashtagsArticleId { get; set; }
 
     public string ArticleVersion { get; set; } // Assuming version could be a string like "1.0", "2.0", etc.
 }

--- a/UoWRepo/Core/Domain/ArticleDataModel.cs
+++ b/UoWRepo/Core/Domain/ArticleDataModel.cs
@@ -74,7 +74,7 @@ public class ArticleDataModel : Linq2DbEntity, IArticleDataModel, IBaseTEntity
     //[Unique] // Mark this field as unique. Note: [Unique] is not a standard DataAnnotations attribute. You may need a custom validation or handle it differently depending on your ORM.
     public string? TitleForUrl { get; set; } // Property name corrected and updated
 
-    [Column(Name = "HashtagsId")] // Updated column name
+    [Column(Name = "HashtagsArticleId")] // Updated column name
     [Nullable]
-    public int? HashtagsId { get; set; } // Property name updated
+    public int? HashtagsArticleId { get; set; } // Property name updated
 }

--- a/UoWRepo/Core/EFDomain/ArticleDataModel.cs
+++ b/UoWRepo/Core/EFDomain/ArticleDataModel.cs
@@ -49,8 +49,8 @@ public class ArticleDataModel : TEntity, IArticleDataModel, ITEntity
     [Column("TitleForUrl")] // Corrected and updated column name to TitleForUrl
     public string? TitleForUrl { get; set; } // Updated property name to TitleForUrl and made nullable
 
-    [Column("HashtagsId")] // Updated column name to HashtagsId
-    public int? HashtagsId { get; set; } // Updated property name to HashtagsId
+    [Column("HashtagsArticleId")] // Updated column name to HashtagsId
+    public int? HashtagsArticleId { get; set; } // Updated property name to HashtagsId
 
     [Column("ArticleVersion")] // Column name ArticleVersion remains unchanged
     [StringLength(2)]


### PR DESCRIPTION
Changed HashtagsId to HashtagsArticleId across several files to better reflect its purpose and to align with the naming conventions. The changes were made in the IArticleDataModel interface, and the ArticleDataModel class definitions in both Linq2DbEntity and TEntity representations.