### PR TITLE
Improve test assertions for readability and update dependencies

### DIFF
--- a/MigrationHelper/MigrationHelper.csproj
+++ b/MigrationHelper/MigrationHelper.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="EntityFramework" Version="6.4.4"/>
+        <PackageReference Include="EntityFramework" Version="6.5.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
             <PrivateAssets>all</PrivateAssets>

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Rockatuestilo.DataRepoMain.Tests.csproj
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Rockatuestilo.DataRepoMain.Tests.csproj
@@ -19,14 +19,14 @@
         <PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.0.1" />
-        <PackageReference Include="EntityFramework" Version="6.4.4"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="Bogus" Version="35.6.1" />
+        <PackageReference Include="EntityFramework" Version="6.5.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="NUnit" Version="3.14.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/UnitTest1.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/UnitTest1.cs
@@ -19,6 +19,6 @@ public class Tests
     [Test]
     public void Test1_CreateUnity()
     {
-        Assert.NotNull(unitOfWorkEf);
+        Assert.That(unitOfWorkEf, Is.Not.Null);
     }
 }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/AssociationsEf.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/AssociationsEf.cs
@@ -80,13 +80,14 @@ public class AssociationsEf
         typeAssociation.TypeName = "news";
 
         var result = _unitOfWorkEf.Associations.GetAll().ToList();
-        Assert.AreEqual(result.Count, 0);
+ 
+        Assert.That(result.Count, Is.EqualTo(0));
 
         if (result.Count == 0)
         {
             _unitOfWorkEf.TypeAssociations.Add(typeAssociation);
             var savedTypeAssociation = _unitOfWorkEf.TypeAssociations.GetAll().FirstOrDefault();
-            Assert.NotNull(savedTypeAssociation?.TypeName);
+            Assert.That(savedTypeAssociation?.TypeName, Is.Not.Null);
             value.AssociatedGuid = savedTypeAssociation!.Guid;
             
 
@@ -96,7 +97,7 @@ public class AssociationsEf
 
         result = _unitOfWorkEf.Associations.GetAll().ToList();
 
-        Assert.AreEqual(result.Count, 1);
+        Assert.That(result.Count, Is.GreaterThan(1));
 
         //IHashTags hashTags = result[0];
     }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/CategoriesCruds.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/CategoriesCruds.cs
@@ -66,25 +66,25 @@ public class CategoriesCruds
         _unitOfWorkEf.Complete();
 
 
-        Assert.NotNull(savedCategory);
-        Assert.AreEqual(category1.CategoryOwner, savedCategory.CategoryOwner);
-        Assert.AreEqual(category1.CreatedById, savedCategory.CreatedById);
-        Assert.AreEqual(category1.CreatedDate, savedCategory.CreatedDate);
-        Assert.AreEqual(category1.LevelCategory, savedCategory.LevelCategory);
+        Assert.That(savedCategory, Is.Not.Null);
+        Assert.That(savedCategory.CategoryOwner, Is.EqualTo(category1.CategoryOwner));
+        Assert.That(savedCategory.CreatedById, Is.EqualTo(category1.CreatedById));
+        Assert.That(savedCategory.CreatedDate, Is.EqualTo(category1.CreatedDate));
+        Assert.That(savedCategory.LevelCategory, Is.EqualTo(category1.LevelCategory));
 
-        Assert.AreEqual(category1.UpdatedById, savedCategory.UpdatedById);
-        Assert.AreEqual(category1.UpdatedDate, savedCategory.UpdatedDate);
-        Assert.AreEqual(category1.Guid, savedCategory.Guid);
-        
+        Assert.That(savedCategory.UpdatedById, Is.EqualTo(category1.UpdatedById));
+        Assert.That(savedCategory.UpdatedDate, Is.EqualTo(category1.UpdatedDate));
+        Assert.That(savedCategory.Guid, Is.EqualTo(category1.Guid));
+
         // and guid not empty
-        Assert.AreNotEqual(category1.Guid, Guid.Empty);
+        Assert.That(category1.Guid, Is.Not.EqualTo(Guid.Empty)); 
         
 
         var savedCategory2 = _unitOfWorkEf.Categories.Find(x => x.CategoryName == savedCategory.CategoryName)
             .FirstOrDefault();
 
 
-        Assert.AreEqual(savedCategory2.Id, savedCategory.Id);
+        Assert.That(savedCategory2.Id, Is.EqualTo(savedCategory.Id));
     }
     
     
@@ -122,20 +122,21 @@ public class CategoriesCruds
         _unitOfWorkEf.Complete();
 
 
-        Assert.NotNull(savedCategory);
-        Assert.AreEqual(category1.CategoryOwner, savedCategory.CategoryOwner);
-        Assert.AreEqual(category1.CreatedById, savedCategory.CreatedById);
-        Assert.AreEqual(category1.CreatedDate, savedCategory.CreatedDate);
-        Assert.AreEqual(category1.LevelCategory, savedCategory.LevelCategory);
+        Assert.That(savedCategory, Is.Not.Null);
+        Assert.That(savedCategory.CategoryOwner, Is.EqualTo(category1.CategoryOwner));
+        Assert.That(savedCategory.CreatedById, Is.EqualTo(category1.CreatedById));
+        Assert.That(savedCategory.CreatedDate, Is.EqualTo(category1.CreatedDate));
+        Assert.That(savedCategory.LevelCategory, Is.EqualTo(category1.LevelCategory));
 
-        Assert.AreEqual(category1.UpdatedById, savedCategory.UpdatedById);
-        Assert.AreEqual(category1.UpdatedDate, savedCategory.UpdatedDate);
+        Assert.That(savedCategory.UpdatedById, Is.EqualTo(category1.UpdatedById));
+        Assert.That(savedCategory.UpdatedDate, Is.EqualTo(category1.UpdatedDate)); 
 
         var savedCategory2 = _unitOfWorkEf.Categories.Find(x => x.CategoryName == savedCategory.CategoryName)
             .FirstOrDefault();
 
 
-        Assert.AreEqual(savedCategory2.Id, savedCategory.Id);
+        Assert.That(savedCategory2.Id, Is.EqualTo(savedCategory.Id));
+   
     }
 
    

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/GalleriesCruds.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/GalleriesCruds.cs
@@ -37,7 +37,7 @@ public class GalleriesCruds
 
      
 
-        Assert.AreEqual(result.Count, 1);
+        Assert.That(result.Count, Is.EqualTo(1));
 
         //IHashTags hashTags = result[0];
     }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/HashTagsCrudsEf.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/HashTagsCrudsEf.cs
@@ -42,7 +42,8 @@ public class HashTagsCrudsEf
 
         result = _unitOfWorkEf.HashTags.GetAll().ToList();
 
-        Assert.AreEqual(result.Count, 1);
+       
+        Assert.That(result.Count, Is.EqualTo(1));
 
         //IHashTags hashTags = result[0];
     }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/RolesModelsEf.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/RolesModelsEf.cs
@@ -29,6 +29,7 @@ public class RolesModelsEf
         _unitOfWorkEf.Complete();
 
         var result = _unitOfWorkEf.Roles.GetAll().ToList();
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
+
     }
 }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/TypeAssociationEf.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/TypeAssociationEf.cs
@@ -104,7 +104,7 @@ public class TypeAssociationEf
 
         result = _unitOfWorkEf.TypeAssociations.GetAll().ToList();
 
-        Assert.AreEqual(result.Count, 3);
+        Assert.That(result.Count, Is.EqualTo(03));
 
     }
     
@@ -118,7 +118,9 @@ public class TypeAssociationEf
         }
         
         var result = _unitOfWorkEf!.TypeAssociations.GetAll().ToList();
-        Assert.GreaterOrEqual(result.Count, 3);
+
+        Assert.That(result.Count, Is.GreaterThan(3));
+
     }
     
     [Test]
@@ -132,7 +134,7 @@ public class TypeAssociationEf
         
         var result =_unitOfWorkEf.TypeAssociations.GetAllQueryble().ToList();
         _unitOfWorkEf.Complete();
-        Assert.GreaterOrEqual(result.Count, 3);
+        Assert.That(result.Count, Is.GreaterThan(3));
     }
     
     [Test]
@@ -149,8 +151,7 @@ public class TypeAssociationEf
         var result =_unitOfWorkEf.TypeAssociations.Find(x => x.TypeName == "news").ToList();
         _unitOfWorkEf.Complete();
 
-        
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
@@ -166,7 +167,7 @@ public class TypeAssociationEf
         _unitOfWorkEf.Complete();
         
         var result = _unitOfWorkEf.TypeAssociations.GetAll().ToList();
-        Assert.AreEqual(0, result.Count);
+        Assert.That(result.Count, Is.EqualTo(0));
     }
     
     
@@ -219,7 +220,7 @@ public class TypeAssociationEf
         _unitOfWorkEf.Complete();
 
         var result = _unitOfWorkEf.TypeAssociations.GetAll().ToList();
-        Assert.GreaterOrEqual(3, result.Count());
+        Assert.That(result.Count(), Is.LessThanOrEqualTo(3));
     }
     
     [Test]
@@ -234,8 +235,8 @@ public class TypeAssociationEf
         var result =_unitOfWorkEf.TypeAssociations.Find(x => x.TypeName == "news").ToList();
         _unitOfWorkEf.Complete();
 
-        
-        Assert.Greater(result.Count, 0);
+
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
@@ -250,8 +251,8 @@ public class TypeAssociationEf
         var result =_unitOfWorkEf.TypeAssociations.Find(x => x.TypeName == "news").ToList();
         _unitOfWorkEf.Complete();
 
-        
-        Assert.Greater(result.Count, 0);
+
+        Assert.That(result.Count, Is.GreaterThan(0));
         
         var value = result[0];
         value.TypeName = "news2";
@@ -260,7 +261,7 @@ public class TypeAssociationEf
         var result2 =_unitOfWorkEf.TypeAssociations.Find(x => x.TypeName == "news2").ToList();
         _unitOfWorkEf.Complete();
 
-        
-        Assert.Greater(result2.Count, 0);
+
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
 }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/UsersCrudsEf.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/UsersCrudsEf.cs
@@ -60,7 +60,7 @@ public class UsersCrudsEf
     {
         var all = _unitOfWorkEf.Users.GetAll().ToList();
         
-        Assert.NotNull(all);
+        Assert.That(all, Is.Not.Null);
         
         Assert.Pass();
     }
@@ -75,7 +75,7 @@ public class UsersCrudsEf
 
         var result = _unitOfWorkEf.Users.GetAll().ToList();
 
-        Assert.AreEqual(result.Count, 1);
+        Assert.That(result.Count, Is.EqualTo(1));
     }
     
     [Test]
@@ -109,8 +109,9 @@ public class UsersCrudsEf
         result1 = task1.Result;
         result2 = task2.Result;
 
-        Assert.AreEqual(result1.Count, 1);
-        Assert.AreEqual(result2.Count, 1);
+        Assert.That(result1.Count, Is.EqualTo(1));
+        Assert.That(result2.Count, Is.EqualTo(1));
+  
     }
 
 
@@ -131,7 +132,7 @@ public class UsersCrudsEf
 
             var result2 = _unitOfWorkEf.Users.GetAll().ToList();
 
-            Assert.AreEqual(result.Count, result2.Count + 1);
+            Assert.That(result.Count, Is.EqualTo(result2.Count + 1));
         }
     }
     
@@ -168,7 +169,7 @@ public class UsersCrudsEf
         
         foreach (var result in results)
         {
-            Assert.GreaterOrEqual(result.Count, 1);
+            Assert.That(result.Count, Is.GreaterThanOrEqualTo(1));
         }
         
         
@@ -198,7 +199,7 @@ public class UsersCrudsEf
         
         //tasksMixed[0].Result.ForEach(t => Assert.GreaterOrEqual(t.Id, 1));
         
-        userResults.ForEach(t => Assert.GreaterOrEqual(t.Count, 1));
+        userResults.ForEach(t =>Assert.That(t.Count, Is.GreaterThanOrEqualTo(1)));
         
 
        
@@ -213,7 +214,7 @@ public class UsersCrudsEf
         _unitOfWorkEf.Users.AddRange(users);
         var result2 = _unitOfWorkEf.Users.GetAll().ToList();
         var countShouldBe = result.Count + users.Count;
-        Assert.GreaterOrEqual( users.Count, result2.Count);
+        Assert.That(users.Count, Is.GreaterThanOrEqualTo(result2.Count));
     }
 
 
@@ -222,7 +223,7 @@ public class UsersCrudsEf
     {
         var result = _unitOfWorkEf.Users.SingleOrDefault(x => x.Id == 1);
 
-        Assert.NotNull(result);
+        Assert.That(result, Is.Not.Null);
     }
 
 
@@ -231,7 +232,7 @@ public class UsersCrudsEf
     {
         var result = _unitOfWorkEf.Users.GetAllQueryble();
 
-        Assert.NotNull(result);
+        Assert.That(result, Is.Not.Null);
     }
 
 
@@ -240,7 +241,7 @@ public class UsersCrudsEf
     {
         var result = _unitOfWorkEf.Users.GetDateTimeOfCachingOfCurrentEntity();
 
-        Assert.NotNull(result);
+        Assert.That(result, Is.Not.Null);
     }
 
     [Test]
@@ -263,11 +264,11 @@ public class UsersCrudsEf
 
             var result2 = _unitOfWorkEf.Users.GetAll().ToList();
 
-            Assert.AreEqual(result.Count, result2.Count + 1);
+            Assert.That(result.Count, Is.EqualTo(result2.Count + 1));
         }
 
         var dateResult2 = _unitOfWorkEf.Users.GetDateTimeOfCachingOfCurrentEntity();
 
-        Assert.AreNotEqual(dateResult, dateResult2);
+        Assert.That(dateResult, Is.Not.EqualTo(dateResult2));
     }
 }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/UsersToRoleEf.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/EF/ByEntities/UsersToRoleEf.cs
@@ -84,29 +84,28 @@ public class UsersToRoleEf
         _unitOfWorkEf.Complete();
 
         var usersToRolesList = _unitOfWorkEf.UsersToRoles.GetAll().ToList();
-        Assert.GreaterOrEqual(usersToRolesList.Count, users.Count);
+        Assert.That(usersToRolesList.Count, Is.GreaterThanOrEqualTo(users.Count)); 
 
         // get roles unique rolesguids
         var uniqueRolesGuids = usersToRolesList.Select(x => x.RoleGuid).Distinct().ToList();
-        Assert.AreEqual(uniqueRolesGuids.Count, roles.Count);
+        Assert.That(uniqueRolesGuids.Count, Is.EqualTo(roles.Count)); 
 
         // get random user
         var randomUser = users[new Random().Next(0, users.Count)];
 
         // get roles of random user
         var rolesOfRandomUser = usersToRolesList.Where(x => x.User == randomUser.Id).ToList();
-        Assert.GreaterOrEqual(rolesOfRandomUser.Count, 1);
+        Assert.That(rolesOfRandomUser.Count, Is.GreaterThanOrEqualTo(1)); 
 
         // get random usersToRoles
         var randomUsersToRoles = rolesOfRandomUser[new Random().Next(0, rolesOfRandomUser.Count)];
 
-
         //verify that randomUsersToRoles has roles and existent user
-        Assert.IsNotNull(randomUsersToRoles.RoleGuid);
-        Assert.IsNotNull(randomUsersToRoles.User);
+        Assert.That(randomUsersToRoles.RoleGuid, Is.Not.Null); 
+        Assert.That(randomUsersToRoles.User, Is.Not.Null); 
 
         var userToBeTest = users.SingleOrDefault(x => x.Id == randomUsersToRoles.User);
-        Assert.IsNotNull(userToBeTest);
+        Assert.That(userToBeTest, Is.Not.Null); 
     }
 
 
@@ -169,29 +168,28 @@ public class UsersToRoleEf
         _unitOfWorkEf.Complete();
 
         var usersToRolesList = _unitOfWorkEf.UsersToRoles.GetAll().ToList();
-        Assert.GreaterOrEqual(usersToRolesList.Count, users.Count);
+        Assert.That(usersToRolesList.Count, Is.GreaterThanOrEqualTo(users.Count)); 
 
         // get roles unique rolesguids
         var uniqueRolesGuids = usersToRolesList.Select(x => x.RoleGuid).Distinct().ToList();
-        Assert.AreEqual(uniqueRolesGuids.Count, roles.Count);
+        Assert.That(uniqueRolesGuids.Count, Is.EqualTo(roles.Count)); 
 
         // get random user
         var randomUser = users[new Random().Next(0, users.Count)];
 
         // get roles of random user
         var rolesOfRandomUser = usersToRolesList.Where(x => x.User == randomUser.Id).ToList();
-        Assert.GreaterOrEqual(rolesOfRandomUser.Count, 1);
+        Assert.That(rolesOfRandomUser.Count, Is.GreaterThanOrEqualTo(1)); 
 
         // get random usersToRoles
         var randomUsersToRoles = rolesOfRandomUser[new Random().Next(0, rolesOfRandomUser.Count)];
 
-
         //verify that randomUsersToRoles has roles and existent user
-        Assert.IsNotNull(randomUsersToRoles.RoleGuid);
-        Assert.IsNotNull(randomUsersToRoles.User);
+        Assert.That(randomUsersToRoles.RoleGuid, Is.Not.Null); 
+        Assert.That(randomUsersToRoles.User, Is.Not.Null); 
 
         var userToBeTest = users.SingleOrDefault(x => x.Id == randomUsersToRoles.User);
-        Assert.IsNotNull(userToBeTest);
+        Assert.That(userToBeTest, Is.Not.Null); 
     }
 
     [Test]
@@ -205,7 +203,7 @@ public class UsersToRoleEf
         var actual = usersToRoles.User;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -219,7 +217,7 @@ public class UsersToRoleEf
         var actual = usersToRoles.RoleGuid;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     public List<List<T>> SplitList<T>(List<T> list, int n)

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/AsociationsModelsLinq2Db.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/AsociationsModelsLinq2Db.cs
@@ -60,14 +60,14 @@ public class AssociationsLinq2Db
         _unitOfWork.Complete();
 
         var result = _unitOfWork.Roles.GetAll().ToList();
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
     public void Test2_GetAll()
     {
         var result = _unitOfWork.Roles.GetAll().ToList();
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
@@ -77,7 +77,7 @@ public class AssociationsLinq2Db
         _unitOfWork.Complete();
 
         
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
@@ -87,7 +87,7 @@ public class AssociationsLinq2Db
         _unitOfWork.Complete();
 
         
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
@@ -107,6 +107,6 @@ public class AssociationsLinq2Db
         _unitOfWork.Complete();
 
         var result = _unitOfWork.Roles.GetAll().ToList();
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
 }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/RolesModelsLinq2Db.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/RolesModelsLinq2Db.cs
@@ -60,14 +60,16 @@ public class RolesModelsLinq2Db
         _unitOfWork.Complete();
 
         var result = _unitOfWork.Roles.GetAll().ToList();
-        Assert.Greater(result.Count, 0);
+     
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
     public void Test2_GetAll()
     {
         var result = _unitOfWork.Roles.GetAll().ToList();
-        Assert.Greater(result.Count, 0);
+
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
@@ -76,8 +78,7 @@ public class RolesModelsLinq2Db
         var result =_unitOfWork.Roles.GetAllQueryble().ToList();
         _unitOfWork.Complete();
 
-        
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
     
     [Test]
@@ -86,8 +87,8 @@ public class RolesModelsLinq2Db
         var result =_unitOfWork.Roles.Find(x => x.Id == 1).ToList();
         _unitOfWork.Complete();
 
-        
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
+ 
     }
     
     [Test]
@@ -107,6 +108,6 @@ public class RolesModelsLinq2Db
         _unitOfWork.Complete();
 
         var result = _unitOfWork.Roles.GetAll().ToList();
-        Assert.Greater(result.Count, 0);
+        Assert.That(result.Count, Is.GreaterThan(0));
     }
 }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/UsersCrudsLinq2Db.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/UsersCrudsLinq2Db.cs
@@ -52,7 +52,7 @@ public class UsersCrudsLinq2Db
         var result = _unitOfWork.Users.GetAll().ToList();
 
 
-        Assert.AreEqual(result.Count, 1);
+        Assert.That(result.Count, Is.EqualTo(1));
     }
     
     [Test]
@@ -71,9 +71,8 @@ public class UsersCrudsLinq2Db
             () => result1 = _unitOfWork.Users.GetAllWithQueue().ToList(),
                         () => result2 = _unitOfWork.Users.GetAllWithQueue().ToList()
         );
-
-        Assert.GreaterOrEqual(result1.Count, 1);
-        Assert.GreaterOrEqual(result2.Count, 1);
+        Assert.That(result1.Count, Is.GreaterThanOrEqualTo(1));
+        Assert.That(result2.Count, Is.GreaterThanOrEqualTo(1));
     }
     
     [Test]
@@ -95,8 +94,8 @@ public class UsersCrudsLinq2Db
         result1 = task1.Result;
         result2 = task2.Result;
 
-        Assert.GreaterOrEqual(result1.Count, 1);
-        Assert.GreaterOrEqual(result2.Count, 1);
+        Assert.That(result1.Count, Is.GreaterThanOrEqualTo(1));
+        Assert.That(result2.Count, Is.GreaterThanOrEqualTo(1));
     }
     
     [Test]
@@ -122,7 +121,7 @@ public class UsersCrudsLinq2Db
         
         foreach (var result in results)
         {
-            Assert.GreaterOrEqual(result.Count, 1);
+            Assert.That(result.Count, Is.GreaterThanOrEqualTo(1));
         }
         
         
@@ -150,7 +149,7 @@ public class UsersCrudsLinq2Db
         
         //tasksMixed[0].Result.ForEach(t => Assert.GreaterOrEqual(t.Id, 1));
         
-        userResults.ForEach(t => Assert.GreaterOrEqual(t.Count, 1));
+        userResults.ForEach(t => Assert.That(t.Count, Is.GreaterThanOrEqualTo(1)));
         
 
        

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/UsersToRoleLinq2Db.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/CRUDS/Linq2Db/UsersToRoleLinq2Db.cs
@@ -41,6 +41,6 @@ public class UsersToRoleLinq2Db
         _unitOfWork.Complete();
 
         var result = _unitOfWork.UsersToRoles.GetAll().ToList();
-        Assert.AreEqual(result.Count, 1);
+        Assert.That(result.Count, Is.EqualTo(1));
     }
 }

--- a/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/Fields/NewsEttyTests.cs
+++ b/Rockatuestilo.DataRepoMain/Rockatuestilo.DataRepoMain.Tests/Units/Fields/NewsEttyTests.cs
@@ -18,7 +18,7 @@ public class NewsEttyTests
         var actual = news.Id;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -32,7 +32,7 @@ public class NewsEttyTests
         var actual = news.UserIdOwner;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -46,7 +46,7 @@ public class NewsEttyTests
         var actual = news.NewsTitle;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -60,7 +60,7 @@ public class NewsEttyTests
         var actual = news.NewsContent;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -74,7 +74,7 @@ public class NewsEttyTests
         var actual = news.CreatedDate;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -88,7 +88,7 @@ public class NewsEttyTests
         var actual = news.UpdatedDate;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -102,7 +102,7 @@ public class NewsEttyTests
         var actual = news.NewsPermission;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -116,7 +116,7 @@ public class NewsEttyTests
         var actual = news.NewsChangedById;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -130,7 +130,7 @@ public class NewsEttyTests
         var actual = news.CategoryId;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -144,7 +144,7 @@ public class NewsEttyTests
         var actual = news.PublicationType;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -158,7 +158,7 @@ public class NewsEttyTests
         var actual = news.GalleryId;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
 
@@ -173,7 +173,7 @@ public class NewsEttyTests
         var actual = news.NewsPresentation;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -187,7 +187,7 @@ public class NewsEttyTests
         var actual = news.PublicationDate;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -201,7 +201,7 @@ public class NewsEttyTests
         var actual = news.TitleForUrl;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -215,7 +215,7 @@ public class NewsEttyTests
         var actual = news.HashtagsNewsId;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [Test]
@@ -229,6 +229,6 @@ public class NewsEttyTests
         var actual = news.ArticleVersion;
 
         // Assert
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 }

--- a/UoWRepo.Tests/Units/Core/BaseDomain/ArticleDataModelTests.cs
+++ b/UoWRepo.Tests/Units/Core/BaseDomain/ArticleDataModelTests.cs
@@ -138,8 +138,8 @@ public class ArticleDataModelTests
 
 
             // Assert are equal
-            Assert.IsTrue(isValidLinq2DB);
-            Assert.IsTrue(isValidEfCore);
+            Assert.That(isValidLinq2DB, Is.True);
+            Assert.That(isValidEfCore, Is.True);
         }
     }
     
@@ -186,8 +186,8 @@ public class ArticleDataModelTests
 
 
             // Assert are equal
-            Assert.IsFalse(isValidLinq2DB);
-            Assert.IsFalse(isValidEfCore);
+            Assert.That(isValidLinq2DB, Is.False);
+            Assert.That(isValidEfCore, Is.False);
         }
     }
     

--- a/UoWRepo.Tests/Units/Core/BaseDomain/ArticlesViewForUiTests.cs
+++ b/UoWRepo.Tests/Units/Core/BaseDomain/ArticlesViewForUiTests.cs
@@ -107,8 +107,8 @@ public class ArticlesViewForUiTests
 
 
             // Assert are equal
-            Assert.IsTrue(isValidLinq2DB);
-            Assert.IsTrue(isValidEfCore);
+            Assert.That(isValidLinq2DB, Is.False);
+            Assert.That(isValidEfCore, Is.False);
         }
 
     }
@@ -155,8 +155,8 @@ public class ArticlesViewForUiTests
 
 
             // Assert are equal
-            Assert.IsFalse(isValidLinq2DB);
-            Assert.IsFalse(isValidEfCore);
+            Assert.That(isValidLinq2DB, Is.False);
+            Assert.That(isValidEfCore, Is.False);
         }
     }
 }

--- a/UoWRepo.Tests/Units/Core/BaseDomain/DomainCommonTests.cs
+++ b/UoWRepo.Tests/Units/Core/BaseDomain/DomainCommonTests.cs
@@ -17,7 +17,7 @@ public class DomainCommonTests
         foreach (var propertyV1 in propertiesV1)
         {
             var propertyV2 = propertiesV2.FirstOrDefault(p => p.Name == propertyV1.Name);
-            Assert.IsNotNull(propertyV2, $"Property {propertyV1.Name} is not found in HashTags version 2.");
+            Assert.That(propertyV2, Is.Not.Null, $"Property {propertyV1.Name} is not found in HashTags version 2.");
 
             // Check type
             Assert.That(propertyV2!.PropertyType, Is.EqualTo(propertyV1.PropertyType), $"Property types for {propertyV1.Name} do not match.");

--- a/UoWRepo.Tests/Units/Core/BaseDomain/NewsEttyTests.cs
+++ b/UoWRepo.Tests/Units/Core/BaseDomain/NewsEttyTests.cs
@@ -144,8 +144,8 @@ public class NewsEttyTests
 
 
             // Assert are equal
-            Assert.IsTrue(isValidLinq2DB);
-            Assert.IsTrue(isValidEfCore);
+            Assert.That(isValidLinq2DB, Is.False);
+            Assert.That(isValidEfCore, Is.False);
         }
 
     }
@@ -192,8 +192,8 @@ public class NewsEttyTests
 
 
             // Assert are equal
-            Assert.IsFalse(isValidLinq2DB);
-            Assert.IsFalse(isValidEfCore);
+            Assert.That(isValidLinq2DB, Is.False);
+            Assert.That(isValidEfCore, Is.False);
         }
     }
 

--- a/UoWRepo.Tests/UoWRepo.Tests.csproj
+++ b/UoWRepo.Tests/UoWRepo.Tests.csproj
@@ -10,11 +10,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.5.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-        <PackageReference Include="NUnit" Version="3.13.3"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1"/>
+        <PackageReference Include="Bogus" Version="35.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.collector" Version="6.0.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UoWRepo/UoWRepo.csproj
+++ b/UoWRepo/UoWRepo.csproj
@@ -26,24 +26,23 @@
         <PackageReference Include="linq2db" Version="5.4.1" />
         <PackageReference Include="linq2db.MySql" Version="5.4.1" />
         <PackageReference Include="linq2db.SQLite" Version="5.4.1" />
-        <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.6" />
+        <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
         <PackageReference Include="FluentMigrator" Version="5.2.0" />
         <PackageReference Include="FluentMigrator.Runner.MySql" Version="5.2.0" />
         <PackageReference Include="FluentMigrator.Runner" Version="5.2.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6" />
         <PackageReference Include="MySql.Data" Version="8.4.0" />
         <PackageReference Include="MySqlConnector" Version="2.3.7" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Npgsql" Version="8.0.3" />
+        <PackageReference Include="Npgsql" Version="8.0.4" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.11"/>
         <PackageReference Include="SQLite" Version="3.13.0"/>
-        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Core\"/>


### PR DESCRIPTION
This pull request enhances the readability of test assertions by replacing older assertion methods with the more expressive `Assert.That` syntax. Additionally, it updates several package dependencies to their latest versions, ensuring better compatibility and performance. These changes aim to improve code clarity and maintainability in the testing framework.