### PR TITLE
fix: Update ArticleDataModel and Galleries classes to include Guid_bi…

### DIFF
--- a/UoWRepo/Core/EFDomain/ArticleDataModel.cs
+++ b/UoWRepo/Core/EFDomain/ArticleDataModel.cs
@@ -66,6 +66,11 @@ public class ArticleDataModel : TEntity, IArticleDataModel, ITEntity
     [Column("Guid_bin", TypeName = "binary(16)")]
     //[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public byte[] GuidBin { get; set; } = default!;
+    
+
+    [Column("CategoryGuid_bin", TypeName = "binary(16)")]
+    //[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public byte[]? CategoryGuid_bin { get; set; } 
 
     
     /// <summary>

--- a/UoWRepo/Core/EFDomain/Galleries.cs
+++ b/UoWRepo/Core/EFDomain/Galleries.cs
@@ -25,4 +25,14 @@ public class Galleries : TEntity, ITEntity
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     [Column("galleryID")]
     public new int Id { get; set; }
+    
+    // NOT NULL
+    [Required]
+    [Column("GUID")]
+    public Guid Guid { get; set; }
+    
+    // NEW: binary mirrors (computed in DB)
+    [Column("Guid_bin", TypeName = "binary(16)")]
+    //[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public byte[] GuidBin { get; set; } = default!;
 }

--- a/UoWRepo/UoWRepo.csproj
+++ b/UoWRepo/UoWRepo.csproj
@@ -11,9 +11,9 @@
         <PackageTags>rockatuestilo rock metal</PackageTags>
         <Company>rockatuestilo</Company>
         <Product>Rockatuestilo.DataRepoMain</Product>
-        <AssemblyVersion>10.2.1</AssemblyVersion>
-        <PackageVersion>10.2.1</PackageVersion>
-        <FileVersion>10.2.1</FileVersion>
+        <AssemblyVersion>10.2.3</AssemblyVersion>
+        <PackageVersion>10.2.3</PackageVersion>
+        <FileVersion>10.2.3</FileVersion>
         <LangVersion>latestmajor</LangVersion>
         <Nullable>enable</Nullable>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
…n properties and update project version to 10.2.3

## Summary by Sourcery

Add required GUID and binary GUID mirror properties to Galleries and ArticleDataModel, and bump project version to 10.2.3

Enhancements:
- Add non-nullable GUID column to Galleries
- Introduce GuidBin binary(16) property to Galleries
- Add optional CategoryGuid_bin binary(16) property to ArticleDataModel

Build:
- Update project version to 10.2.3 in UoWRepo.csproj