### PR TITLE
fix: Add Guid_bin property to Categories class, remove Guid property …

### DIFF
--- a/UoWRepo/Core/EFDomain/Categories.cs
+++ b/UoWRepo/Core/EFDomain/Categories.cs
@@ -30,5 +30,12 @@ public class Categories : TEntity, ITEntity
     [Required]
     [Column("GUID")]
     public Guid Guid { get; set; }
+    
+    // NEW: binary mirrors (computed in DB)
+    [Column("Guid_bin", TypeName = "binary(16)")]
+    //[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public byte[] GuidBin { get; set; } = default!;
+    
+    
 }
 

--- a/UoWRepo/Core/EFDomain/Galleries.cs
+++ b/UoWRepo/Core/EFDomain/Galleries.cs
@@ -26,13 +26,4 @@ public class Galleries : TEntity, ITEntity
     [Column("galleryID")]
     public new int Id { get; set; }
     
-    // NOT NULL
-    [Required]
-    [Column("GUID")]
-    public Guid Guid { get; set; }
-    
-    // NEW: binary mirrors (computed in DB)
-    [Column("Guid_bin", TypeName = "binary(16)")]
-    //[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-    public byte[] GuidBin { get; set; } = default!;
 }

--- a/UoWRepo/UoWRepo.csproj
+++ b/UoWRepo/UoWRepo.csproj
@@ -11,9 +11,9 @@
         <PackageTags>rockatuestilo rock metal</PackageTags>
         <Company>rockatuestilo</Company>
         <Product>Rockatuestilo.DataRepoMain</Product>
-        <AssemblyVersion>10.2.3</AssemblyVersion>
-        <PackageVersion>10.2.3</PackageVersion>
-        <FileVersion>10.2.3</FileVersion>
+        <AssemblyVersion>10.2.4</AssemblyVersion>
+        <PackageVersion>10.2.4</PackageVersion>
+        <FileVersion>10.2.4</FileVersion>
         <LangVersion>latestmajor</LangVersion>
         <Nullable>enable</Nullable>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
…from Galleries class, and update project version to 10.2.4

## Summary by Sourcery

Remove the GUID and its binary mirror from the Galleries EF model, add a computed binary GUID mirror to the Categories EF model, and bump the project version to 10.2.4.

Bug Fixes:
- Remove Guid and GuidBin properties from Galleries class

Enhancements:
- Add GuidBin binary mirror property to Categories class

Build:
- Update project version to 10.2.4